### PR TITLE
:bug: Release G1-G3 from JTAG control

### DIFF
--- a/src/mod-stm32f1-v4.cpp
+++ b/src/mod-stm32f1-v4.cpp
@@ -99,14 +99,17 @@ hal::output_pin& output_g0()
 }
 hal::output_pin& output_g1()
 {
+  hal::stm32f1::release_jtag_pins();
   return gpio<hal::stm32f1::output_pin, 1>();
 }
 hal::output_pin& output_g2()
 {
+  hal::stm32f1::release_jtag_pins();
   return gpio<hal::stm32f1::output_pin, 2>();
 }
 hal::output_pin& output_g3()
 {
+  hal::stm32f1::release_jtag_pins();
   return gpio<hal::stm32f1::output_pin, 3>();
 }
 }  // namespace hal::micromod::v1

--- a/src/mod-stm32f1-v5.cpp
+++ b/src/mod-stm32f1-v5.cpp
@@ -99,14 +99,17 @@ hal::output_pin& output_g0()
 }
 hal::output_pin& output_g1()
 {
+  hal::stm32f1::release_jtag_pins();
   return gpio<hal::stm32f1::output_pin, 1>();
 }
 hal::output_pin& output_g2()
 {
+  hal::stm32f1::release_jtag_pins();
   return gpio<hal::stm32f1::output_pin, 2>();
 }
 hal::output_pin& output_g3()
 {
+  hal::stm32f1::release_jtag_pins();
   return gpio<hal::stm32f1::output_pin, 3>();
 }
 hal::output_pin& output_g4()


### PR DESCRIPTION
This is required to use these pins as GPIO