### PR TITLE
:greeen_heart: Remove demo building from deploy

### DIFF
--- a/.github/workflows/deploy_version.yml
+++ b/.github/workflows/deploy_version.yml
@@ -75,9 +75,6 @@ jobs:
       - name: 📦 Build package using ${{ inputs.profile }} @ MinSizeRel
         run: conan create . -pr ${{ inputs.profile }} -pr ${{ inputs.compiler_profile }} -s build_type=MinSizeRel --version=${{ env.VERSION }}
 
-      - name: 🏗️ Build demos for ${{ inputs.profile }} @ MinSizeRel
-        run: conan build demos -pr ${{ inputs.profile }} -pr ${{ inputs.compiler_profile }} -s build_type=Release --version=${{ env.VERSION }}
-
       - name: 📡 Sign into JFrog Artifactory
         if: ${{ inputs.version != '' }}
         env:


### PR DESCRIPTION
Building the demos in deploy is problematic since demos can only be upgraded once a version has been deployed. Chicken and egg problem.